### PR TITLE
allow to overwrite certain module settings

### DIFF
--- a/exporter.go
+++ b/exporter.go
@@ -182,12 +182,7 @@ func coldStartRequest(target string) error {
 // Define a regular expression which will be matched against the response body. If it matches
 // the probe will be marked as failed.
 //
-// http_basic_auth_username
-// Define a username which will be used for basic auth in the request being made
-//
-// http_basic_auth_password
-// Define a password which will be used for basic auth in the request being made
-func overwriteHTTPModuleParams(params url.Values, conf *config.HTTPProbe) error {
+func overwriteHTTPModuleParams(params url.Values, headers http.Header, conf *config.HTTPProbe) error {
 	for name, value := range params {
 		switch name {
 		case "http_valid_status_codes":
@@ -206,16 +201,6 @@ func overwriteHTTPModuleParams(params url.Values, conf *config.HTTPProbe) error 
 		case "http_fail_on_regexp":
 			// we only support one regexp currently
 			conf.FailIfBodyMatchesRegexp = []string{value[0]}
-		case "http_basic_auth_username":
-			if conf.HTTPClientConfig.BasicAuth == nil {
-				conf.HTTPClientConfig.BasicAuth = &pconfig.BasicAuth{}
-			}
-			conf.HTTPClientConfig.BasicAuth.Username = value[0]
-		case "http_basic_auth_password":
-			if conf.HTTPClientConfig.BasicAuth == nil {
-				conf.HTTPClientConfig.BasicAuth = &pconfig.BasicAuth{}
-			}
-			conf.HTTPClientConfig.BasicAuth.Password = pconfig.Secret(value[0])
 		}
 	}
 	return nil

--- a/exporter.go
+++ b/exporter.go
@@ -5,8 +5,11 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"net/url"
 	"os"
 	"path"
+	"regexp"
+	"strconv"
 	"strings"
 	"time"
 
@@ -15,6 +18,7 @@ import (
 	"github.com/prometheus/blackbox_exporter/config"
 	"github.com/prometheus/blackbox_exporter/prober"
 	"github.com/prometheus/client_golang/prometheus"
+	pconfig "github.com/prometheus/common/config"
 	"github.com/prometheus/common/expfmt"
 )
 
@@ -81,6 +85,10 @@ func Handler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if module.Prober == "http" {
+		if err := overwriteHTTPModuleParams(params, &module.HTTP); err != nil {
+			http.Error(w, fmt.Sprintf("Error during parsing module overwrites: %v", err), http.StatusInternalServerError)
+			return
+		}
 		if err := coldStartRequest(target); err != nil {
 			http.Error(w, fmt.Sprintf("Unable to make a cold start request: %s", err), http.StatusInternalServerError)
 			return
@@ -158,4 +166,92 @@ func coldStartRequest(target string) error {
 	}
 	_, err := client.Get(target)
 	return err
+}
+
+// overwriteModuleParams allows to specify some overwrites for the http prober:
+//
+// http_valid_status_codes
+// Overwrite the valid HTTP status codes of the request being made by defining comma
+// separated status codes. You can also use a shortcut like 2xx for the range of 200-299.
+//
+// http_expect_regexp
+// Define a regular expression which will be matched against the response body. If it matches
+// the probe will be marked as successful.
+//
+// http_fail_on_regexp
+// Define a regular expression which will be matched against the response body. If it matches
+// the probe will be marked as failed.
+//
+// http_basic_auth_username
+// Define a username which will be used for basic auth in the request being made
+//
+// http_basic_auth_password
+// Define a password which will be used for basic auth in the request being made
+func overwriteHTTPModuleParams(params url.Values, conf *config.HTTPProbe) error {
+	for name, value := range params {
+		switch name {
+		case "http_valid_status_codes":
+			var validStatusCodes []int
+			for _, codes := range value {
+				validCodes, err := parseStatusCodes(codes)
+				if err != nil {
+					return err
+				}
+				validStatusCodes = append(validStatusCodes, validCodes...)
+			}
+			conf.ValidStatusCodes = validStatusCodes
+		case "http_expect_regexp":
+			// we only support one regexp currently
+			conf.FailIfBodyNotMatchesRegexp = []string{value[0]}
+		case "http_fail_on_regexp":
+			// we only support one regexp currently
+			conf.FailIfBodyMatchesRegexp = []string{value[0]}
+		case "http_basic_auth_username":
+			if conf.HTTPClientConfig.BasicAuth == nil {
+				conf.HTTPClientConfig.BasicAuth = &pconfig.BasicAuth{}
+			}
+			conf.HTTPClientConfig.BasicAuth.Username = value[0]
+		case "http_basic_auth_password":
+			if conf.HTTPClientConfig.BasicAuth == nil {
+				conf.HTTPClientConfig.BasicAuth = &pconfig.BasicAuth{}
+			}
+			conf.HTTPClientConfig.BasicAuth.Password = pconfig.Secret(value[0])
+		}
+	}
+	return nil
+}
+
+// parseStatusCodes parses the given comma separated status codes
+// it is possible to use shortcuts like 2xx, 3xx, etc which will be expanded
+// to the corresponding whole range of status codes
+func parseStatusCodes(codes string) ([]int, error) {
+	var result []int
+	splittedCodes := strings.Split(codes, ",")
+	for _, code := range splittedCodes {
+		code := strings.TrimSpace(code)
+		match, err := regexp.MatchString("[0-9]xx", code)
+		if err != nil {
+			return nil, err
+		}
+		if match {
+			mainCode, _ := strconv.Atoi(string(code[0]))
+			result = append(result, generateCodeRange(mainCode*100, mainCode*100+99)...)
+			continue
+		}
+		parsed, err := strconv.Atoi(code)
+		if err != nil {
+			return nil, fmt.Errorf("Can not convert status code \"%s\" to a number", code)
+		}
+		result = append(result, parsed)
+	}
+	return result, nil
+}
+
+// generateCodeRange creates a slice with consecutive ints from start to end
+func generateCodeRange(start, end int) []int {
+	result := make([]int, end-start+1)
+	for i := range result {
+		result[i] = start + i
+	}
+	return result
 }

--- a/exporter.go
+++ b/exporter.go
@@ -18,7 +18,6 @@ import (
 	"github.com/prometheus/blackbox_exporter/config"
 	"github.com/prometheus/blackbox_exporter/prober"
 	"github.com/prometheus/client_golang/prometheus"
-	pconfig "github.com/prometheus/common/config"
 	"github.com/prometheus/common/expfmt"
 )
 
@@ -182,7 +181,7 @@ func coldStartRequest(target string) error {
 // Define a regular expression which will be matched against the response body. If it matches
 // the probe will be marked as failed.
 //
-func overwriteHTTPModuleParams(params url.Values, headers http.Header, conf *config.HTTPProbe) error {
+func overwriteHTTPModuleParams(params url.Values, conf *config.HTTPProbe) error {
 	for name, value := range params {
 		switch name {
 		case "http_valid_status_codes":

--- a/exporter_test.go
+++ b/exporter_test.go
@@ -1,27 +1,68 @@
 package exporter
 
 import (
+	"encoding/base64"
 	"fmt"
 	"io/ioutil"
+	"math/rand"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"os"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/alecthomas/assert"
 )
 
-var ts *httptest.Server
+const (
+	testUsername = "test"
+	testPassword = "testPassword"
+)
+
+var ts map[string]*httptest.Server
 
 func TestMain(m *testing.M) {
 	// override sourceCodeDir for test
 	sourceCodeDir = ""
-	ts = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	ts = initTestServers()
+	code := m.Run()
+	for _, server := range ts {
+		server.Close()
+	}
+	os.Exit(code)
+}
+
+func initTestServers() map[string]*httptest.Server {
+	result := make(map[string]*httptest.Server)
+	result["simple"] = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprintln(w, "ok")
 	}))
-	code := m.Run()
-	ts.Close()
-	os.Exit(code)
+	result["basicAuth"] = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		auth := strings.SplitN(r.Header.Get("Authorization"), " ", 2)
+		if len(auth) != 2 || auth[0] != "Basic" {
+			http.Error(w, "authorization failed", http.StatusUnauthorized)
+			return
+		}
+		payload, _ := base64.StdEncoding.DecodeString(auth[1])
+		pair := strings.SplitN(string(payload), ":", 2)
+		if len(pair) != 2 || !(pair[0] == testUsername && pair[1] == testPassword) {
+			http.Error(w, "authorization failed", http.StatusUnauthorized)
+			return
+		}
+		fmt.Fprintln(w, "authorized")
+	}))
+	result["randomClientError"] = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		rand.Seed(time.Now().UnixNano())
+		http.Error(w, "client error", 400+rand.Intn(100))
+	}))
+	result["serverError"] = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		rand.Seed(time.Now().UnixNano())
+		errorCodes := []int{500, 501, 502, 503}
+		http.Error(w, "server error", errorCodes[rand.Intn(len(errorCodes))])
+	}))
+	return result
 }
 
 func TestHandler(t *testing.T) {
@@ -29,27 +70,60 @@ func TestHandler(t *testing.T) {
 		name           string
 		target         string
 		module         string
+		overwrites     url.Values
 		bodyContains   string
 		expectedStatus int
 	}{
-		{"valid target", ts.URL, "http_2xx", "probe_success 1", http.StatusOK},
-		{"default module", ts.URL, "", "probe_success 1", http.StatusOK},
-		{"invalid module", ts.URL, "http_invalid", "Unknown module", http.StatusBadRequest},
-		{"invalid target", "http://doesnot.exist.local", "http_2xx", "probe_success 0", http.StatusOK},
-		{"no target", "", "http_2xx", "Target parameter is missing", http.StatusBadRequest},
+		{"valid target", ts["simple"].URL, "http_2xx", url.Values{}, "probe_success 1", http.StatusOK},
+		{"default module", ts["simple"].URL, "", url.Values{}, "probe_success 1", http.StatusOK},
+		{"invalid module", ts["simple"].URL, "http_invalid", url.Values{}, "Unknown module", http.StatusBadRequest},
+		{"invalid target", "http://doesnot.exist.local", "http_2xx", url.Values{}, "probe_success 0", http.StatusOK},
+		{"no target", "", "http_2xx", url.Values{}, "Target parameter is missing", http.StatusBadRequest},
+		{"simple status code overwrite", ts["simple"].URL, "", urlValue("http_valid_status_codes", "200"), "probe_success 1", http.StatusOK},
+		{"special notation status code", ts["randomClientError"].URL, "", urlValue("http_valid_status_codes", "4xx"), "probe_success 1", http.StatusOK},
+		{"comma separated codes", ts["serverError"].URL, "", urlValue("http_valid_status_codes", "500,501,502,503"), "probe_success 1", http.StatusOK},
+		{"white space comma separated codes", ts["serverError"].URL, "", urlValue("http_valid_status_codes", "500, 501, 502, 503"), "probe_success 1", http.StatusOK},
+		{"positive expect regexp test", ts["simple"].URL, "", urlValue("http_expect_regexp", "[oO][kK]"), "probe_success 1", http.StatusOK},
+		{"negative expect regexp test", ts["simple"].URL, "", urlValue("http_expect_regexp", "fail"), "probe_success 0", http.StatusOK},
+		{"empty expect regexp test", ts["simple"].URL, "", urlValue("http_expect_regexp", ""), "probe_success 1", http.StatusOK},
+		{"invalid expect regexp test", ts["simple"].URL, "", urlValue("http_expect_regexp", "*"), "probe_success 0", http.StatusOK},
+		{"positive fail on regexp test", ts["simple"].URL, "", urlValue("http_fail_on_regexp", "[oO][kK]"), "probe_success 0", http.StatusOK},
+		{"negative fail on regexp test", ts["simple"].URL, "", urlValue("http_fail_on_regexp", "fail"), "probe_success 1", http.StatusOK},
+		{"empty fail on regexp test", ts["simple"].URL, "", urlValue("http_expect_regexp", ""), "probe_success 1", http.StatusOK},
+		{"confusing regexp test", ts["simple"].URL, "", urlValue("http_expect_regexp", "ok", "http_fail_on_regexp", "ok"), "probe_success 0", http.StatusOK},
+		{"positive basic auth test", ts["basicAuth"].URL, "", urlValue("http_basic_auth_username", testUsername, "http_basic_auth_password", testPassword), "probe_success 1", http.StatusOK},
+		{"negative basic auth test", ts["basicAuth"].URL, "", urlValue("http_basic_auth_username", "myUsername", "http_basic_auth_password", "myPassword"), "probe_success 0", http.StatusOK},
+		{"only username basic auth test", ts["basicAuth"].URL, "", urlValue("http_basic_auth_username", testUsername), "probe_success 0", http.StatusOK},
+		{"validate that login is not possible for user", ts["basicAuth"].URL, "", urlValue("http_basic_auth_username", "myUser", "http_basic_auth_password", "myPassword", "http_valid_status_codes", "401"), "probe_success 1", http.StatusOK},
 	}
 	for _, tt := range handlerTests {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
-			req := httptest.NewRequest("GET", "http://exporter/probe?target="+tt.target+"&module="+tt.module, nil)
+			testURL := "http://exporter/probe?target=" + tt.target + "&module=" + tt.module
+			if len(tt.overwrites) > 0 {
+				testURL = testURL + "&" + tt.overwrites.Encode()
+			}
+			fmt.Printf("Using URL: %s\n", testURL)
+			req := httptest.NewRequest("GET", testURL, nil)
 			w := httptest.NewRecorder()
 			Handler(w, req)
 			resp := w.Result()
 			body, err := ioutil.ReadAll(resp.Body)
 			assert.NoError(t, err)
 
-			assert.Equal(t, tt.expectedStatus, resp.StatusCode)
+			assert.Equal(t, tt.expectedStatus, resp.StatusCode, fmt.Sprintf("Expected status code %v, but got %v", tt.expectedStatus, resp.StatusCode))
 			assert.Contains(t, string(body), tt.bodyContains)
 		})
 	}
+}
+
+func urlValue(keyValue ...string) url.Values {
+	if len(keyValue)%2 != 0 {
+		panic("Expected key-value pairs as arguments, but got uneven amount")
+	}
+	uv := url.Values{}
+	for i := 0; i < len(keyValue); i = i + 2 {
+		uv.Add(keyValue[i], keyValue[i+1])
+	}
+	return uv
 }

--- a/exporter_test.go
+++ b/exporter_test.go
@@ -1,7 +1,6 @@
 package exporter
 
 import (
-	"encoding/base64"
 	"fmt"
 	"io/ioutil"
 	"math/rand"
@@ -9,7 +8,6 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"os"
-	"strings"
 	"testing"
 	"time"
 


### PR DESCRIPTION
This PR allows to overwrite certain blackbox exporter HTTP prober settings via URL parameters. This allows for more dynamic probes. Current overwrites supported:

* http response codes
* regexp body checks