### PR TITLE
downgrade to go 1.21

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ninech/blackbox-exporter-cloudfunction
 
-go 1.23
+go 1.21
 
 require (
 	github.com/alecthomas/assert v0.0.0-20170929043011-405dbfeb8e38

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -36,5 +36,5 @@ variable "available_memory_mb" {
 
 variable "runtime" {
   description = "The runtime which the cloudfunction should use. Check https://cloud.google.com/functions/docs/concepts/execution-environment for possible values."
-  default = "go120"
+  default = "go121"
 }


### PR DESCRIPTION
Gen1 cloud functions on GCP only support Golang versions up to v1.21 (https://cloud.google.com/functions/docs/concepts/execution-environment\#go). We therefore try to downgrade again.